### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "import": "./lib/index.mjs",
       "require": "./lib/index.js",
-      "default": "./lib/index.mjs"
+      "default": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
     },
     "./global": "./lib/index.global.js"
   },


### PR DESCRIPTION
added line

"types": "./lib/index.d.ts"

in exports : { "." : { ...

to typescript knowns where the types are whe you exports the module.

<!--
Thank you for contributing! Please fill out the checklist below.
-->

## Summary

Explain the change (what & why).

## Type of change

- [x ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Chore / Maintenance
- [ ] Docs update

## Checklist

- [ ] Code builds locally (npm run build:npm)
- [ ] Linting/format (if applicable) passes
- [ ] Updated documentation (README / docs) if needed
- [ ] Added tests or explanation why not (project currently lacks tests)
- [ ] Version bump NOT included (handled by release process)

## How to test

Steps or code snippet to verify.

When to install in nextjs project typescript could not find file types .d.ts

## Screenshots / Logs

If UI or meaningful logs changed.

## Related issues

Link to issues this PR closes (e.g. Closes #123).

## Additional context

Anything else reviewers should know.
