### PR TITLE
fix: remove invalid bin field from package.json (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "bin": {
-    "getDeviceId()": "./lib/index.js"
-  },
   "keywords": [
     "browserfingerprint",
     "fingerprinting",


### PR DESCRIPTION
Closes #21.

## What

Removes the invalid `bin` field from `package.json`:

```diff
-"bin": {
-    "getDeviceId()": "./lib/index.js"
-}
```

## Why

Broprint.js is a browser library, not a CLI tool. The `bin` field caused npm to install a broken executable command on user systems, and the key `getDeviceId()` was an invalid binary name (contains parentheses).

## Verification

- `npm pack --dry-run` — tarball contents show no bin entries
- `npm run build` — still succeeds
- `npm run lint` — no new warnings/errors