### PR TITLE
fix: remove @ts-nocheck and type cyrb53 (#24)

### DIFF
--- a/src/code/EncryptDecrypt.ts
+++ b/src/code/EncryptDecrypt.ts
@@ -1,12 +1,10 @@
-// @ts-nocheck
 // reference - https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript#answer-52171480
-
 // output - 6533356943844037
-export const cyrb53 = function (str, seed = 0) {
-    let h1 = 0xdeadbeef ^ seed,
-        h2 = 0x41c6ce57 ^ seed;
-    for (let i = 0, ch; i < str.length; i++) {
-        ch = str.charCodeAt(i);
+export const cyrb53 = (str: string, seed: number = 0): number => {
+    let h1 = 0xdeadbeef ^ seed;
+    let h2 = 0x41c6ce57 ^ seed;
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charCodeAt(i);
         h1 = Math.imul(h1 ^ ch, 2654435761);
         h2 = Math.imul(h2 ^ ch, 1597334677);
     }


### PR DESCRIPTION
Closes #24 (partially — audio module's `@ts-nocheck` removed in #22).

Stacked on #49 (issue #25). Retarget after parent merges.

## What

- Drop `@ts-nocheck` from `src/code/EncryptDecrypt.ts`
- Type `cyrb53` as `(str: string, seed?: number) => number`
- Hoist `ch` declaration into the for-loop body so strict mode is happy

## Why

`@ts-nocheck` defeats `"strict": true` in `tsconfig.json` and gives contributors zero IntelliSense. With the unused hash helpers gone (#25), `cyrb53` is the only function left in this file and it types cleanly.

The audio module still has `@ts-nocheck` — it's removed in #22 (full rewrite), where the proper Web Audio API types are added.

## Verification

- `npx tsc --noEmit` passes (strict mode)
- `npm run build` passes
- `npm run lint` passes