### PR TITLE
feat: add options parameter to getCurrentBrowserFingerPrint (#27)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,27 +2,54 @@ import { cyrb53 } from './code/EncryptDecrypt';
 import { getCanvasFingerprint } from './code/GenerateCanvasFingerprint';
 import { generateAudioFingerprint } from './code/generateTheAudioPrints';
 
+export interface BroprintOptions {
+    /** Include audio fingerprinting signal (default: true) */
+    useAudio?: boolean;
+    /** Include canvas fingerprinting signal (default: true) */
+    useCanvas?: boolean;
+    /** Custom seed for the hash function (default: 0) */
+    seed?: number;
+}
+
 /**
  * Generate a stable fingerprint for the current browser.
  *
- * Combines the audio fingerprint with the canvas fingerprint and hashes the
- * concatenation with cyrb53. If audio fingerprinting fails (e.g. unsupported
- * browser), falls back to a canvas-only fingerprint.
+ * Combines the configured signals (audio + canvas by default) and hashes the
+ * result with cyrb53. If audio is enabled but fails (e.g. unsupported browser)
+ * and canvas is also enabled, falls back to a canvas-only fingerprint.
  *
+ * @param options optional signal selection and hash seed.
  * @returns Promise resolving to the fingerprint as a string.
- * @throws if both audio and canvas fingerprinting fail.
+ * @throws if no signals are enabled, or if all enabled signals fail.
  */
-export async function getCurrentBrowserFingerPrint(): Promise<string> {
-    try {
-        const audioResult = await generateAudioFingerprint();
-        const combined = window.btoa(audioResult) + getCanvasFingerprint();
-        return cyrb53(combined, 0).toString();
-    } catch {
+export async function getCurrentBrowserFingerPrint(options: BroprintOptions = {}): Promise<string> {
+    const { useAudio = true, useCanvas = true, seed = 0 } = options;
+
+    if (!useAudio && !useCanvas) {
+        throw new Error(
+            'getCurrentBrowserFingerPrint: at least one of useAudio or useCanvas must be true'
+        );
+    }
+
+    if (useAudio) {
         try {
-            return cyrb53(getCanvasFingerprint(), 0).toString();
-        } catch {
-            throw new Error('Failed to generate the fingerprint of this browser');
+            const audioResult = await generateAudioFingerprint();
+            const combined = useCanvas
+                ? window.btoa(audioResult) + getCanvasFingerprint()
+                : window.btoa(audioResult);
+            return cyrb53(combined, seed).toString();
+        } catch (audioError) {
+            if (!useCanvas) {
+                throw audioError;
+            }
+            // fall through to canvas-only fallback
         }
+    }
+
+    try {
+        return cyrb53(getCanvasFingerprint(), seed).toString();
+    } catch {
+        throw new Error('Failed to generate the fingerprint of this browser');
     }
 }
 


### PR DESCRIPTION
Closes #27.

Stacked on #52. Retarget after parent merges.

## API

```ts
export interface BroprintOptions {
  useAudio?: boolean;   // default: true
  useCanvas?: boolean;  // default: true
  seed?: number;        // default: 0
}

export async function getCurrentBrowserFingerPrint(
  options?: BroprintOptions
): Promise<string>;
```

## Behavior

| `useAudio` | `useCanvas` | Behavior |
|------------|-------------|----------|
| `true` | `true` | Combined fingerprint (default). Audio failure → canvas-only fallback. |
| `true` | `false` | Audio only. Audio failure throws. |
| `false` | `true` | Canvas only. |
| `false` | `false` | Throws immediately. |

`seed` is forwarded to `cyrb53`. Different seeds produce different fingerprints — useful for partitioning IDs across applications.

## Backward compatibility

`getCurrentBrowserFingerPrint()` with no arguments is a no-op semantically — same defaults as before. Type signature is backward-compatible (parameter is optional).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — zero issues
- `npm run build` — passes

README docs land in #39.