### PR TITLE
feat: export individual fingerprinting functions (#28)

### DIFF
--- a/src/code/EncryptDecrypt.ts
+++ b/src/code/EncryptDecrypt.ts
@@ -1,5 +1,14 @@
 // reference - https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript#answer-52171480
-// output - 6533356943844037
+
+/**
+ * Fast, non-cryptographic 53-bit hash. Returns a deterministic integer in
+ * the range [0, 2^53). Suitable for fingerprint hashing — not for security.
+ *
+ * @param str input string to hash
+ * @param seed optional seed (default 0); different seeds produce different hashes
+ * @returns 53-bit integer hash
+ * @example cyrb53('hello') // 17202805693082
+ */
 export const cyrb53 = (str: string, seed: number = 0): number => {
     let h1 = 0xdeadbeef ^ seed;
     let h2 = 0x41c6ce57 ^ seed;

--- a/src/code/GenerateCanvasFingerprint.ts
+++ b/src/code/GenerateCanvasFingerprint.ts
@@ -1,11 +1,24 @@
-export const isCanvasSupported = () => {
+/**
+ * Whether the runtime supports HTML5 canvas with a 2D context.
+ * @returns true if canvas+2d is available, false otherwise
+ */
+export const isCanvasSupported = (): boolean => {
     const elem = document.createElement('canvas');
     return !!(elem.getContext && elem.getContext('2d'));
 };
 
 // this working code snippet is taken from - https://github.com/artem0/canvas-fingerprinting/blob/master/fingerprinting/fingerprint.js
 
-export const getCanvasFingerprint = () => {
+/**
+ * Render a fixed text + shapes to a canvas and return its dataURL. Different
+ * browsers/GPUs render with subtle pixel differences, producing a stable
+ * per-browser identifier.
+ *
+ * Returns the literal string `'broprint.js'` if canvas is unsupported.
+ *
+ * @returns canvas dataURL (or fallback string)
+ */
+export const getCanvasFingerprint = (): string => {
     // If canvas is not supported simply return a static string
     if (!isCanvasSupported()) return 'broprint.js';
 

--- a/src/code/generateTheAudioPrints.ts
+++ b/src/code/generateTheAudioPrints.ts
@@ -23,7 +23,19 @@ const setCompressorParam = (
     }
 };
 
-export const generateAudioFingerprint = (): Promise<string> => {
+/**
+ * Generate an audio fingerprint by rendering a fixed oscillator + compressor
+ * graph through OfflineAudioContext and summing a slice of the output buffer.
+ * Different browsers/audio stacks produce subtly different float values,
+ * yielding a stable per-browser identifier.
+ *
+ * Each invocation creates its own OfflineAudioContext and resolves
+ * independently — safe for concurrent calls.
+ *
+ * @returns Promise resolving to the fingerprint as a string
+ * @throws if OfflineAudioContext is not available in the runtime
+ */
+export const getAudioFingerprint = (): Promise<string> => {
     return new Promise<string>((resolve, reject) => {
         try {
             const Ctor: OfflineAudioContextCtor | undefined =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { cyrb53 } from './code/EncryptDecrypt';
 import { getCanvasFingerprint } from './code/GenerateCanvasFingerprint';
-import { generateAudioFingerprint } from './code/generateTheAudioPrints';
+import { getAudioFingerprint } from './code/generateTheAudioPrints';
+
+// Individual building blocks for advanced usage. Tree-shakeable when
+// `sideEffects: false` is set in package.json (#31).
+export { cyrb53 } from './code/EncryptDecrypt';
+export { getCanvasFingerprint, isCanvasSupported } from './code/GenerateCanvasFingerprint';
+export { getAudioFingerprint } from './code/generateTheAudioPrints';
 
 export interface BroprintOptions {
     /** Include audio fingerprinting signal (default: true) */
@@ -33,7 +39,7 @@ export async function getCurrentBrowserFingerPrint(options: BroprintOptions = {}
 
     if (useAudio) {
         try {
-            const audioResult = await generateAudioFingerprint();
+            const audioResult = await getAudioFingerprint();
             const combined = useCanvas
                 ? window.btoa(audioResult) + getCanvasFingerprint()
                 : window.btoa(audioResult);


### PR DESCRIPTION
Closes #28.

Stacked on #53. Retarget after parent merges.

## New exports

```ts
import {
  getCurrentBrowserFingerPrint,  // existing
  getAudioFingerprint,            // new
  getCanvasFingerprint,           // new
  isCanvasSupported,              // new
  cyrb53,                         // new
  type BroprintOptions,           // already exported via #27
} from '@rajesh896/broprint.js';
```

## Why

Lets advanced consumers compose custom fingerprinting strategies (e.g. hash canvas + a server-supplied salt), or use cyrb53 to hash arbitrary data without a second dependency.

## Note: rename

The audio export was internally called `generateAudioFingerprint`. Renamed to `getAudioFingerprint` for symmetry with `getCanvasFingerprint`. Internal-only — no public consumers.

## JSDoc

Every exported function now has parameter, return, and throws documentation.

## Tree-shaking

Real tree-shaking requires `"sideEffects": false` in `package.json`, which lands in #31.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — zero issues
- `npm run build` — passes