### PR TITLE
chore: add sideEffects:false, engines, prepublishOnly (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     },
     "./global": "./lib/index.global.js"
   },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
   "private": false,
   "scripts": {
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir lib --declarationMap false",
@@ -25,7 +29,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,json,md}\" \"*.{ts,tsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,json,md}\" \"*.{ts,tsx,json}\"",
     "test": "echo \"Error: no test specified\" && exit 1 ",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "npm run build"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -44,12 +49,13 @@
     "registry": "https://registry.npmjs.org/"
   },
   "keywords": [
+    "browser-fingerprint",
     "browserfingerprint",
     "fingerprinting",
     "jsfingerprint",
     "uniquebrowserid",
-    "nodejs",
-    "cryptography",
+    "device-id",
+    "zero-dependency",
     "fraud-detection",
     "canvas-fingerprinting",
     "audio-fingerprinting",


### PR DESCRIPTION
Closes #31.

Stacked on #54. Retarget after parent merges.

## Changes

- **`sideEffects: false`** — enables tree-shaking. Safe because the only side effect (window assignment in `src/index.ts`) is intended for the IIFE/global build; ESM consumers shouldn't be paying for it. Combined with #28's individual exports, advanced users can now `import { cyrb53 } from ...` and pay only for what they use.
- **`engines: { node: '>=18' }`** — documents the floor (matches the CI matrix from #36).
- **`prepublishOnly: 'npm run build'`** — guards against publishing stale `lib/`.
- **Keywords** — drop `nodejs` (browser library) and `cryptography` (cyrb53 is non-cryptographic). Add `browser-fingerprint`, `device-id`, `zero-dependency`.

## Verification

- `npm run build` — passes
- `npm pack --dry-run` — clean tarball, no bin entries