### PR TITLE
ci: add coverage reporting via Codecov (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
         run: npm run format:check
       - name: Type check
         run: npx tsc --noEmit
+      - name: Test + coverage
+        run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        if: matrix.node-version == 20
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          flags: unittests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build
         run: npm run build:npm
       - name: Bundle size budget

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+comment:
+  layout: 'reach,diff,flags,files'
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
Closes #38.

## Summary
Wires `npm run test:coverage` into CI and uploads `coverage/lcov.info` to Codecov on the Node 20 matrix leg (avoids 3x duplicate uploads). Adds `codecov.yml` with project + patch coverage targets at **80%** (matches the Vitest v8 thresholds set in #32).

`fail_ci_if_error: false` is set so a Codecov outage doesn't break PR merges — the Vitest threshold check inside `npm run test:coverage` is already a hard gate.

If `CODECOV_TOKEN` is configured in repo secrets, uploads will be authenticated; otherwise the action falls back to tokenless upload (works for public repos).

The Codecov badge in the README will land in #39 (README rewrite).

## Stack
Targets `ci/37-size-limit` (PR #60). Retarget to `develop` once #60 merges.

## Test plan
- [x] `npm run test:coverage` produces `coverage/lcov.info`
- [x] Vitest threshold (80%) currently passing (96.66/93.54/100/96.66 on covered files)